### PR TITLE
attach drift component automaticaly

### DIFF
--- a/Assets/Project/Scripts/Drifter.cs
+++ b/Assets/Project/Scripts/Drifter.cs
@@ -6,22 +6,14 @@ public class Drifter : MonoBehaviour
 {
 	Transform _child;
 
-	[SerializeField]
-	float _freq;
-	[SerializeField]
-	float _amp;
-	[SerializeField]
-	Vector3 _frontDir;
-	[SerializeField]
-	float _noiseMoveAmp=0;
-	[SerializeField]
-	bool _noiseRotate=false;
-	[SerializeField]
-	float _noiseScale=1;
-	[SerializeField]
-	float _noiseTimeScale=1;
-	[SerializeField]
-	GameObject _wave;
+	public float _freq;
+	public float _amp;
+	public Vector3 _frontDir;
+	public float _noiseMoveAmp=0;
+	public bool _noiseRotate=false;
+	public float _noiseScale=1;
+	public float _noiseTimeScale=1;
+	public GameObject _wave;
 
 	// Start is called before the first frame update
 	void Start()

--- a/Assets/Project/Scripts/Drifter.cs
+++ b/Assets/Project/Scripts/Drifter.cs
@@ -21,6 +21,11 @@ public class Drifter : MonoBehaviour
 		_child = transform.GetChild(0);
 	}
 
+	public Transform GetChild()
+	{
+		return _child;
+	}
+
 	Vector3 GetNoiseDir(Vector3 pos)
 	{
 		float time = Time.time * _noiseTimeScale;

--- a/Assets/Project/Scripts/Drifter.cs
+++ b/Assets/Project/Scripts/Drifter.cs
@@ -8,9 +8,9 @@ public class Drifter : MonoBehaviour
 
 	public float _freq;
 	public float _amp;
-	public Vector3 _frontDir;
+	//public Vector3 _frontDir;
 	public float _noiseMoveAmp=0;
-	public bool _noiseRotate=false;
+	//public bool _noiseRotate=false;
 	public float _noiseScale=1;
 	public float _noiseTimeScale=1;
 	public GameObject _wave;

--- a/Assets/Project/Scripts/DrifterManager.cs
+++ b/Assets/Project/Scripts/DrifterManager.cs
@@ -1,3 +1,4 @@
+using umi.ld50;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -6,8 +7,7 @@ using UnityEngine;
 namespace umi.ld50 {
     public class DrifterManager : MonoBehaviour
     {
-        [SerializeField]
-        private GameObject ship;
+        private PlayerShipLocomoter ship;
         [SerializeField]
         private float deleteDist;
         [SerializeField]
@@ -22,6 +22,7 @@ namespace umi.ld50 {
         // Start is called before the first frame update
         private void Start()
         {
+            ship =  (PlayerShipLocomoter)FindObjectOfType(typeof(PlayerShipLocomoter));
         }
 
         private Vector3 GenerateRandomBasePosition()
@@ -41,10 +42,25 @@ namespace umi.ld50 {
             return new Vector3(generateComponent(), 0, generateComponent());
         }
 
+        void GC(Vector3 shipPosition)
+        {
+            //削除対象を集める(for/foreachの中で要素を削除するとエラーで怒られたり、要素数がずれたりするので、2周に分ける)
+            List<Transform> removingObjects = new List<Transform>();
+            foreach(Transform drifter in gameObject.transform){
+                Vector3 position = drifter.transform.position;
+                float dist = Vector3.Distance(position, shipPosition);
+                if (deleteDist < dist) removingObjects.Add(drifter);
+            }
+            //削除
+            foreach (var drifter in removingObjects)
+                Destroy(drifter.gameObject);
+        }
+
         // Update is called once per frame
         void Update()
         {
-            Vector3 shipPosition = ship.transform.position;
+            Vector3 shipPosition = ship.gameObject.transform.position;
+            GC(shipPosition);
             
             if (this.transform.childCount<maxDrifterNum)
             {

--- a/Assets/Project/Scripts/DrifterManager.cs
+++ b/Assets/Project/Scripts/DrifterManager.cs
@@ -8,30 +8,30 @@ namespace umi.ld50 {
     public class DrifterManager : MonoBehaviour
     {
         [SerializeField]
-        private PlayerShip ship;
+        private PlayerShip _ship;
         [SerializeField]
-        private float deleteDist;
+        private float _deleteDist;
         [SerializeField]
-        private float spawnDist;
+        private float _spawnDist;
         [SerializeField]
-        private int maxDrifterNum;
+        private int _maxDrifterNum;
         [SerializeField]
-        private List<GameObject> drifterPrefabs;
+        private List<GameObject> _drifterPrefabs;
         [SerializeField]
-        private DriftParameter driftParameter;
+        private DriftParameter _driftParameter;
 
         // Start is called before the first frame update
         private void Start()
         {
-            if (ship==null)
-                ship =  (PlayerShip)FindObjectOfType(typeof(PlayerShip));
+            if (_ship==null)
+                _ship =  (PlayerShip)FindObjectOfType(typeof(PlayerShip));
         }
 
         private Vector3 GenerateRandomBasePosition()
         {
             float generateComponent()
             {
-                float c = UnityEngine.Random.Range(spawnDist, deleteDist);
+                float c = UnityEngine.Random.Range(_spawnDist, _deleteDist);
                 if (UnityEngine.Random.value < .5)
                 {
                     return c;
@@ -51,7 +51,7 @@ namespace umi.ld50 {
             foreach(Transform drifter in gameObject.transform){
                 Vector3 position = drifter.transform.position;
                 float dist = Vector3.Distance(position, shipPosition);
-                if (deleteDist < dist) removingObjects.Add(drifter);
+                if (_deleteDist < dist) removingObjects.Add(drifter);
             }
             //削除
             foreach (var drifter in removingObjects)
@@ -61,34 +61,40 @@ namespace umi.ld50 {
         // Update is called once per frame
         void Update()
         {
-            Vector3 shipPosition = ship.gameObject.transform.position;
+            Vector3 shipPosition = _ship.gameObject.transform.position;
             GC(shipPosition);
             
-            if (this.transform.childCount<maxDrifterNum)
+            if (this.transform.childCount<_maxDrifterNum)
             {
                 // 漂流物の初期位置を計算する
                 Vector3 basePosition = GenerateRandomBasePosition();
                 Vector3 position = shipPosition + basePosition;
 
-                int index = UnityEngine.Random.Range(0, drifterPrefabs.Count);
-                GameObject prefab = drifterPrefabs[index];
+                int index = UnityEngine.Random.Range(0, _drifterPrefabs.Count);
+                GameObject prefab = _drifterPrefabs[index];
                 // TODO ランダムで大きさ&向きを変える
-                GameObject drifter = Instantiate (prefab, position, Quaternion.identity);
-                drifter.transform.parent = gameObject.transform;
+                GameObject driftObj = Instantiate (prefab, position, Quaternion.identity);
+                driftObj.transform.parent = gameObject.transform;
 
-                Drifter _drifter = drifter.AddComponent<Drifter>();
-                _drifter._freq = driftParameter.freq;
-                _drifter._amp = driftParameter.amp;
-                _drifter._wave = driftParameter.wave;
+                var drifter = driftObj.AddComponent<Drifter>();
+                drifter._freq = _driftParameter._freq;
+                drifter._amp = _driftParameter._amp;
+                drifter._noiseMoveAmp = _driftParameter._noiseMoveAmp;
+                drifter._noiseScale = _driftParameter._noiseScale;
+                drifter._noiseTimeScale = _driftParameter._noiseTimeScale;
+                drifter._wave = _driftParameter._wave==null? ((Waves)FindObjectOfType(typeof(Waves))).gameObject : _driftParameter._wave;
             }
         }
 
         [Serializable]
         public struct DriftParameter
         {
-            public float freq;
-            public float amp;
-            public GameObject wave;
+            public float _freq;
+            public float _amp;
+            public float _noiseMoveAmp;
+            public float _noiseScale;
+            public float _noiseTimeScale;
+            public GameObject _wave;
         }
     }
 }

--- a/Assets/Project/Scripts/DrifterManager.cs
+++ b/Assets/Project/Scripts/DrifterManager.cs
@@ -19,12 +19,9 @@ namespace umi.ld50 {
         [SerializeField]
         private DriftParameter driftParameter;
 
-        private List<GameObject> managedDrifters;
-
         // Start is called before the first frame update
         private void Start()
         {
-            managedDrifters = new List<GameObject>();
         }
 
         private Vector3 GenerateRandomBasePosition()
@@ -44,31 +41,12 @@ namespace umi.ld50 {
             return new Vector3(generateComponent(), 0, generateComponent());
         }
 
-        void GC(Vector3 shipPosition)
-        {
-            //削除対象を集める(for/foreachの中で要素を削除するとエラーで怒られたり、要素数がずれたりするので、2周に分ける)
-            List<GameObject> removingObjects = new List<GameObject>();
-            foreach (var drifter in managedDrifters)
-            {
-                Vector3 position = drifter.transform.position;
-                float dist = Vector3.Distance(position, shipPosition);
-                if (deleteDist < dist) removingObjects.Add(drifter);
-            }
-            //削除
-            foreach (var drifter in removingObjects)
-            {
-                managedDrifters.Remove(drifter);
-                Destroy(drifter);
-            }
-        }
-
         // Update is called once per frame
         void Update()
         {
             Vector3 shipPosition = ship.transform.position;
-            GC(shipPosition);
             
-            if (managedDrifters.Count<maxDrifterNum)
+            if (this.transform.childCount<maxDrifterNum)
             {
                 // 漂流物の初期位置を計算する
                 Vector3 basePosition = GenerateRandomBasePosition();
@@ -83,8 +61,6 @@ namespace umi.ld50 {
                 _drifter._freq = driftParameter.freq;
                 _drifter._amp = driftParameter.amp;
                 _drifter._wave = driftParameter.wave;
-
-                managedDrifters.Add(drifter);
             }
         }
 

--- a/Assets/Project/Scripts/DrifterManager.cs
+++ b/Assets/Project/Scripts/DrifterManager.cs
@@ -7,7 +7,8 @@ using UnityEngine;
 namespace umi.ld50 {
     public class DrifterManager : MonoBehaviour
     {
-        private PlayerShipLocomoter ship;
+        [SerializeField]
+        private PlayerShip ship;
         [SerializeField]
         private float deleteDist;
         [SerializeField]
@@ -22,7 +23,8 @@ namespace umi.ld50 {
         // Start is called before the first frame update
         private void Start()
         {
-            ship =  (PlayerShip)FindObjectOfType(typeof(PlayerShip));
+            if (ship==null)
+                ship =  (PlayerShip)FindObjectOfType(typeof(PlayerShip));
         }
 
         private Vector3 GenerateRandomBasePosition()

--- a/Assets/Project/Scripts/DrifterManager.cs
+++ b/Assets/Project/Scripts/DrifterManager.cs
@@ -72,6 +72,7 @@ namespace umi.ld50 {
 
                 int index = UnityEngine.Random.Range(0, drifterPrefabs.Count);
                 GameObject prefab = drifterPrefabs[index];
+                // TODO ランダムで大きさ&向きを変える
                 GameObject drifter = Instantiate (prefab, position, Quaternion.identity);
                 drifter.transform.parent = gameObject.transform;
 

--- a/Assets/Project/Scripts/DrifterManager.cs
+++ b/Assets/Project/Scripts/DrifterManager.cs
@@ -22,7 +22,7 @@ namespace umi.ld50 {
         // Start is called before the first frame update
         private void Start()
         {
-            ship =  (PlayerShipLocomoter)FindObjectOfType(typeof(PlayerShipLocomoter));
+            ship =  (PlayerShip)FindObjectOfType(typeof(PlayerShip));
         }
 
         private Vector3 GenerateRandomBasePosition()

--- a/Assets/Project/Scripts/DrifterManager.cs
+++ b/Assets/Project/Scripts/DrifterManager.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -15,6 +16,8 @@ namespace umi.ld50 {
         private int maxDrifterNum;
         [SerializeField]
         private List<GameObject> drifterPrefabs;
+        [SerializeField]
+        private DriftParameter driftParameter;
 
         private List<GameObject> managedDrifters;
 
@@ -28,8 +31,8 @@ namespace umi.ld50 {
         {
             float generateComponent()
             {
-                float c = Random.Range(spawnDist, deleteDist);
-                if (Random.value < .5)
+                float c = UnityEngine.Random.Range(spawnDist, deleteDist);
+                if (UnityEngine.Random.value < .5)
                 {
                     return c;
                 }
@@ -71,11 +74,26 @@ namespace umi.ld50 {
                 Vector3 basePosition = GenerateRandomBasePosition();
                 Vector3 position = shipPosition + basePosition;
 
-                int index = Random.Range(0, drifterPrefabs.Count);
+                int index = UnityEngine.Random.Range(0, drifterPrefabs.Count);
                 GameObject prefab = drifterPrefabs[index];
                 GameObject drifter = Instantiate (prefab, position, Quaternion.identity);
+                drifter.transform.parent = gameObject.transform;
+
+                Drifter _drifter = drifter.AddComponent<Drifter>();
+                _drifter._freq = driftParameter.freq;
+                _drifter._amp = driftParameter.amp;
+                _drifter._wave = driftParameter.wave;
+
                 managedDrifters.Add(drifter);
             }
+        }
+
+        [Serializable]
+        public struct DriftParameter
+        {
+            public float freq;
+            public float amp;
+            public GameObject wave;
         }
     }
 }


### PR DESCRIPTION
- drift managerの子オブジェクトとしてdrfiterを足します
- drift managerで生成するオブジェクトにdrfit componentを足します
- drifterにchildを返すだけの関数を足す
- 自動的にplayershipを取得するようにします
-  ほかのスクリプトに合わせて外出しパラメータのprefixに_を追加