### PR TITLE
ダメージ計算の処理を修正 #169

### DIFF
--- a/Assets/Project/Scripts/PlayerShip.cs
+++ b/Assets/Project/Scripts/PlayerShip.cs
@@ -144,6 +144,7 @@ namespace umi.ld50
                 else
                 {
                     _parts.Push(latest);
+                    break;
                 }
             }
             if(emitBreakEvent) OnBreakPartsAction();


### PR DESCRIPTION
設置物を破壊できない程度のダメージが残った場合全てのパーツにダメージが入り続けていた問題を修正